### PR TITLE
Fix for new INPCBindings failing to bind to DataContext after ViewModel has been set

### DIFF
--- a/src/Assets/ugui-mvvm/DataContext.cs
+++ b/src/Assets/ugui-mvvm/DataContext.cs
@@ -151,7 +151,11 @@ namespace uguimvvm
 
         public void AddDependentProperty(INPCBinding.PropertyPath prop, PropertyChangedEventHandler handler)
         {
-            _dependents.Add(new DependentProperty(prop, handler));
+            var dependentProperty = new DependentProperty(prop, handler);
+            dependentProperty.Prop.AddHandler(_value, dependentProperty.Handler);
+            dependentProperty.Prop.TriggerHandler(_value);
+
+            _dependents.Add(dependentProperty);
         }
 
         public class DependentProperty

--- a/src/Assets/ugui-mvvm/DataContext.cs
+++ b/src/Assets/ugui-mvvm/DataContext.cs
@@ -153,7 +153,6 @@ namespace uguimvvm
         {
             var dependentProperty = new DependentProperty(prop, handler);
             dependentProperty.Prop.AddHandler(_value, dependentProperty.Handler);
-            dependentProperty.Prop.TriggerHandler(_value);
 
             _dependents.Add(dependentProperty);
         }


### PR DESCRIPTION
This PR proposes a fix for [issue #9](https://github.com/jbruening/ugui-mvvm/issues/9) that is encountered when an INPCBinding's Awake() is called after the ViewModel of a DataContext has already been set, this can occur if the INPCBinding is instantiated, enabled, or if InstantiateOnAwake is set for its bound DataContext.

Since handlers are only set up in the UpdateValue call on either DataContext.Awake() or when setting the ViewModel if an INPCBinding attempts to bind to a DataContext after the ViewModel has been set no change notification handlers will be set up until the next time the DataContext ViewModel is refreshed.

The proposed fix is to call AddHandler in AddDependentProperty, which is called by FigureBindings() as part of Awake() for an INPCBinding.