### PR TITLE
Fix usability issues in binding and DataContext inspector code

### DIFF
--- a/src/Assets/ugui-mvvm/DataContext.cs
+++ b/src/Assets/ugui-mvvm/DataContext.cs
@@ -32,7 +32,8 @@ namespace uguimvvm
 
         [SerializeField]
         private INPCBinding.ComponentPath _propertyBinding = null;
-        public Component Component { get { return _propertyBinding.Component; } }
+        public INPCBinding.ComponentPath PropertyBinding => _propertyBinding;
+        public Component Component { get { return _propertyBinding?.Component; } }
         private INPCBinding.PropertyPath _prop;
 
         [Tooltip("Instantiate the type on awake. This will not work for UnityEngine.Object types")]

--- a/src/Assets/ugui-mvvm/Editor/CommandBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/CommandBindingEditor.cs
@@ -14,6 +14,7 @@ class CommandBindingEditor : Editor
     private SerializedProperty _vprop;
     private SerializedProperty _vmprop;
     private SerializedProperty _veprop;
+    private string _focusedControl;
 
 #region scene post processing
     [PostProcessScene(1)]
@@ -77,13 +78,19 @@ class CommandBindingEditor : Editor
 
     public override void OnInspectorGUI()
     {
+        // Only update the focused element name during the Layout event, since all controls must be static between Layout & Repaint.
+        if (Event.current.type == EventType.Layout)
+        {
+            _focusedControl = GUI.GetNameOfFocusedControl();
+        }
+
         serializedObject.Update();
 
         EditorGUILayout.PropertyField(_vprop);
         if (_vprop.objectReferenceValue != null)
             INPCBindingEditor.DrawComponentEvents(_vprop, _veprop);
 
-        INPCBindingEditor.DrawCRefProp(serializedObject.targetObject.GetInstanceID(), _vmprop, GUIContent.none, typeof(ICommand));
+        INPCBindingEditor.DrawCRefProp(serializedObject.targetObject.GetInstanceID(), _focusedControl, _vmprop, GUIContent.none, typeof(ICommand));
 
         var rect = EditorGUILayout.GetControlRect(true, EditorGUIUtility.singleLineHeight);
         var label = EditorGUI.BeginProperty(rect, null, _parmprop);

--- a/src/Assets/ugui-mvvm/Editor/DataContextEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/DataContextEditor.cs
@@ -17,7 +17,7 @@ class DataContextEditor : Editor
     private Vector2 _scrollPos;
     private Type _tval;
     private string _focusedControl;
-    private bool hasFocusedSearchControl = false;
+    private bool _hasFocusedSearchControl = false;
 
     public override void OnInspectorGUI()
     {
@@ -64,7 +64,7 @@ class DataContextEditor : Editor
 
         if (_tval != null)
         {
-            hasFocusedSearchControl = false;
+            _hasFocusedSearchControl = false;
             _searchString = EditorGUILayout.TextField(SearchFieldLabel, _tval.FullName);
             if (_searchString != _tval.FullName)
             {
@@ -133,10 +133,10 @@ class DataContextEditor : Editor
         // Only update the focused control at the very end of the draw call, and only update the focus once when the user starts a search.
         if (_tval == null && !string.IsNullOrEmpty(_searchString))
         {
-            if (!hasFocusedSearchControl)
+            if (!_hasFocusedSearchControl)
             {
                 EditorGUI.FocusTextInControl(SearchFieldControlName);
-                hasFocusedSearchControl = true;
+                _hasFocusedSearchControl = true;
             }
         }
     }

--- a/src/Assets/ugui-mvvm/INPCBinding.cs
+++ b/src/Assets/ugui-mvvm/INPCBinding.cs
@@ -290,6 +290,7 @@ namespace uguimvvm
 
         [SerializeField]
         ComponentPath _view;
+        public ComponentPath View => _view;
 
 #pragma warning disable 0169
 
@@ -302,6 +303,7 @@ namespace uguimvvm
 
         [SerializeField]
         ComponentPath _viewModel;
+        public ComponentPath ViewModel => _viewModel;
 
         [SerializeField]
         BindingMode _mode = BindingMode.OneWayToView;


### PR DESCRIPTION
Fixing a few issues that were causing property discoverability to fail for game objects with a large number of monobehaviours as well as some general issues with inspector usability.

Changes include:
- Fixing INPCBinding, CommandBinding, and DataContext property path lookup help window to only check whether it should be displayed if the text field is focused during the Layout event, not on repaint or key events.  This has to be done at the very start of the first call of OnInspectorGUI() per frame (denoted by EventType.Layout) to guarantee a consistent control layout throughout the frame & a valid value from the previous frame.
- Remove non-interactable toggle on Property Paths, since this was occluding the property lookup box, and that info is already communicated by the exposed error message when unset.
- Expose ComponentPaths for View & ViewModel on INPCBindings as public properties which brings them in line with the surface area of CommandBinding & DataContext.
- Update the search text field for DataContexts to only set focus once on create, and only at the end of the draw call to avoid losing focus to Unity Editor UI.