### PR TITLE
Switch from Begin/End to Scopes

### DIFF
--- a/src/Assets/ugui-mvvm/Editor/CommandBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/CommandBindingEditor.cs
@@ -86,35 +86,35 @@ class CommandBindingEditor : Editor
         INPCBindingEditor.DrawCRefProp(serializedObject.targetObject.GetInstanceID(), _vmprop, GUIContent.none, typeof(ICommand));
 
         var rect = EditorGUILayout.GetControlRect(true, EditorGUIUtility.singleLineHeight);
-        var label = EditorGUI.BeginProperty(rect, null, _parmprop);
-        GUI.Label(rect, label);
-
-        //parameter type
-        var typeProp = _parmprop.FindPropertyRelative("Type");
-        var trect = rect;
-        trect.x += EditorGUIUtility.labelWidth;
-        trect.width -= EditorGUIUtility.labelWidth;
-        EditorGUI.PropertyField(trect, typeProp);
-
-        //value field
-        var typeValue = (BindingParameterType)Enum.GetValues(typeof(BindingParameterType)).GetValue(typeProp.enumValueIndex);
-        SerializedProperty valueProp = null;
-        switch(typeValue)
+        using (var propertyScope = new EditorGUI.PropertyScope(rect, null, _parmprop))
         {
-            case BindingParameterType.None:
-                break;
-            default:
-                valueProp = _parmprop.FindPropertyRelative(typeValue.ToString());
-                break;
-        }
-        if (valueProp != null)
-        {
-            EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(valueProp);
-            EditorGUI.indentLevel--;
-        }
+            GUI.Label(rect, propertyScope.content);
 
-        EditorGUI.EndProperty();
+            //parameter type
+            var typeProp = _parmprop.FindPropertyRelative("Type");
+            var trect = rect;
+            trect.x += EditorGUIUtility.labelWidth;
+            trect.width -= EditorGUIUtility.labelWidth;
+            EditorGUI.PropertyField(trect, typeProp);
+
+            //value field
+            var typeValue = (BindingParameterType)Enum.GetValues(typeof(BindingParameterType)).GetValue(typeProp.enumValueIndex);
+            SerializedProperty valueProp = null;
+            switch (typeValue)
+            {
+                case BindingParameterType.None:
+                    break;
+                default:
+                    valueProp = _parmprop.FindPropertyRelative(typeValue.ToString());
+                    break;
+            }
+            if (valueProp != null)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(valueProp);
+                EditorGUI.indentLevel--;
+            }
+        }
 
         serializedObject.ApplyModifiedProperties();
     }

--- a/src/Assets/ugui-mvvm/Editor/DataContextEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/DataContextEditor.cs
@@ -117,16 +117,18 @@ class DataContextEditor : Editor
 
             if (_types != null)
             {
-                _scrollPos = EditorGUILayout.BeginScrollView(_scrollPos, GUILayout.Height(100));
-                foreach (var type in _types)
+                using (var scrollViewScope = new EditorGUILayout.ScrollViewScope(_scrollPos, GUILayout.Height(100)))
                 {
-                    if (GUILayout.Button(type.FullName))
+                    _scrollPos = scrollViewScope.scrollPosition;
+                    foreach (var type in _types)
                     {
-                        _tval = type;
-                        tprop.stringValue = _tval.AssemblyQualifiedName;
+                        if (GUILayout.Button(type.FullName))
+                        {
+                            _tval = type;
+                            tprop.stringValue = _tval.AssemblyQualifiedName;
+                        }
                     }
                 }
-                EditorGUILayout.EndScrollView();
             }
         }
 
@@ -135,9 +137,10 @@ class DataContextEditor : Editor
         var dc = target as DataContext;
         if (dc != null)
         {
-            EditorGUI.BeginDisabledGroup(true);
-            EditorGUILayout.Toggle("Value is non-null?", dc.Value != null);
-            EditorGUI.EndDisabledGroup();
+            using (var disabledGroupScope = new EditorGUI.DisabledGroupScope(true))
+            {
+                EditorGUILayout.Toggle("Value is non-null?", dc.Value != null);
+            }
         }
     }
 }


### PR DESCRIPTION
When exceptions are thrown inside the scope, the scopes are always cleaned up correctly.  Aka, the "End" version is always called.

Also it's easier to verify that every Begin is matched correctly with an End.