### PR TITLE
Append a number to duplicate component name entries in dropdown

### DIFF
--- a/src/Assets/ugui-mvvm/Editor/ComponentReferenceDrawer.cs
+++ b/src/Assets/ugui-mvvm/Editor/ComponentReferenceDrawer.cs
@@ -68,7 +68,7 @@ class ComponentReferenceDrawer : PropertyDrawer
                     if (!existingComponents.ContainsKey(componentName))
                     {
                         // For this loop through the components, this is the first one we've hit with this name.
-                        existingComponents[componentName] = 0;
+                        existingComponents[componentName] = 1;
                     }
                     else
                     {


### PR DESCRIPTION
This is needed because UnityEditor.EditorGUI.Popup hides duplicate entries.  So we must give each item a unique name for it to show.  Plus, this is helpful for users to pick one.