### PR TITLE
Handle typename where one startswith another

### DIFF
--- a/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
+++ b/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
@@ -70,7 +70,7 @@ namespace uguimvvm
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (results.Count == 1 && results[0].Value == currentValue)
+                if (results.Any() && results[0].Value == currentValue)
                 {
                     SelectedType = results[0].Type;
                 }


### PR DESCRIPTION
If one typename is exactly equal to another plus some appended string, then it was impossible to select the shorter typename.  This change fixes that.

For example:
MyClass
MyClass2

It would have been impossible to select MyClass in the DataContextEditor.  Now it works correctly.