### PR TITLE
Fixed TypeSuggestionProvider to not suggest CompilerGenerated classes

### DIFF
--- a/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
+++ b/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
@@ -62,6 +62,7 @@ namespace uguimvvm
                     .AsParallel()
                     .WithCancellation(cancellationToken)
                     .Select((t) => new TypeSuggestion(t, currentValue))
+                    .Where((t) => Attribute.GetCustomAttribute(t, typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)) == null)
                     .Where((s) => s.DisplayTextMatchIndex >= 0)
                     .OrderBy(opt => opt.DisplayTextMatchIndex)
                     .ThenBy(opt => opt.Value.Length)


### PR DESCRIPTION
Fixes an issue where CompilerGeneratedAttributes would show up as suggested classes in the DataContext ViewModel type suggestion menu.

Note - Other suggested attributes are not included. I decided to opt for an 'as needed' approach, and since I haven't seen any other extra classes in the suggestions yet, it seemed like it wasn't necessary to add these other exclusions pre emptively.

Also, GeneratedCodeAttribute was not included because it might be possible for generated code to be legitimate view models