### PR TITLE
Make the generic ValueConverter methods virtual

### DIFF
--- a/src/Assets/ugui-mvvm/Converters/ValueConverter.cs
+++ b/src/Assets/ugui-mvvm/Converters/ValueConverter.cs
@@ -54,7 +54,7 @@ namespace uguimvvm.converters
             this.targetComparer = tTargetComparer;
         }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (itemLookup == null)
             {
@@ -84,7 +84,7 @@ namespace uguimvvm.converters
             }
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!allowTwoWayConversion)
             {


### PR DESCRIPTION
Recently ran into a use case where a user might want to perform some sort of application specific  pre-processing or post processing on the item mapping key-value pairs . 

Example - the keyvalue pair could be an enum -> string mapping, but if we want a localized string, the string mapped result might need app specific post processing. 