### PR TITLE
Add better support for "view to view" bindings

### DIFF
--- a/src/Assets/ugui-mvvm/BindingMode.cs
+++ b/src/Assets/ugui-mvvm/BindingMode.cs
@@ -22,4 +22,17 @@ namespace uguimvvm
         [EditorBrowsable(EditorBrowsableState.Never)]
         OneWayToViewModel = OneWayToSource,
     }
+
+    public static class BindingModeExtensions
+    {
+        public static bool IsTargetBoundToSource(this BindingMode bindingMode)
+        {
+            return bindingMode != BindingMode.OneWayToSource;
+        }
+
+        public static bool IsSourceBoundToTarget(this BindingMode bindingMode)
+        {
+            return bindingMode == BindingMode.OneWayToSource || bindingMode == BindingMode.TwoWay;
+        }
+    }
 }

--- a/src/Assets/ugui-mvvm/BindingMode.cs
+++ b/src/Assets/ugui-mvvm/BindingMode.cs
@@ -27,7 +27,7 @@ namespace uguimvvm
     {
         public static bool IsTargetBoundToSource(this BindingMode bindingMode)
         {
-            return bindingMode != BindingMode.OneWayToSource;
+            return bindingMode == BindingMode.OneWayToTarget || bindingMode == BindingMode.TwoWay;
         }
 
         public static bool IsSourceBoundToTarget(this BindingMode bindingMode)

--- a/src/Assets/ugui-mvvm/BindingUpdateTrigger.cs
+++ b/src/Assets/ugui-mvvm/BindingUpdateTrigger.cs
@@ -3,7 +3,6 @@
     public enum BindingUpdateTrigger
     {
         None,
-        Polling,
         PropertyChangedEvent,
         UnityEvent,
     }

--- a/src/Assets/ugui-mvvm/DataContext.cs
+++ b/src/Assets/ugui-mvvm/DataContext.cs
@@ -45,7 +45,7 @@ namespace uguimvvm
         void Awake()
         {
             if (_propertyBinding != null && _propertyBinding.Component != null)
-                _prop = uguimvvm.PropertyBinding.FigureBinding(_propertyBinding, this.BindingPropertyChanged, true);
+                _prop = uguimvvm.PropertyBinding.FigureBinding(_propertyBinding, this.ApplyBindingToValue, true);
 
             ApplyBindingToValue();
 
@@ -77,7 +77,7 @@ namespace uguimvvm
                 if (_value != null)
                 {
                     item.Prop.AddHandler(_value, item.Handler);
-                    item.Prop.TriggerHandler(_value);
+                    item.Prop.TriggerHandler();
                 }
             }
 
@@ -133,12 +133,6 @@ namespace uguimvvm
         }
 
 #region property binding
-        private void BindingPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == "" || e.PropertyName == _propertyBinding.Property)
-                ApplyBindingToValue();
-        }
-
         private void ApplyBindingToValue()
         {
             if (_propertyBinding == null) return;
@@ -150,7 +144,7 @@ namespace uguimvvm
         }
 #endregion
 
-        public void AddDependentProperty(PropertyBinding.PropertyPath prop, PropertyChangedEventHandler handler)
+        public void AddDependentProperty(PropertyBinding.PropertyPath prop, Action handler)
         {
             var dependentProperty = new DependentProperty(prop, handler);
             dependentProperty.Prop.AddHandler(_value, dependentProperty.Handler);
@@ -161,9 +155,9 @@ namespace uguimvvm
         public class DependentProperty
         {
             public PropertyBinding.PropertyPath Prop { get; private set; }
-            public PropertyChangedEventHandler Handler { get; private set; }
+            public Action Handler { get; private set; }
 
-            public DependentProperty(PropertyBinding.PropertyPath prop, PropertyChangedEventHandler handler)
+            public DependentProperty(PropertyBinding.PropertyPath prop, Action handler)
             {
                 Prop = prop;
                 Handler = handler;

--- a/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
+++ b/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
@@ -14,7 +14,7 @@ namespace uguimvvm
 
     public class DropDownMenu
     {
-        private List<DropDownItem> _dropDownItems = new List<DropDownItem>();
+        private readonly List<DropDownItem> _dropDownItems = new List<DropDownItem>();
         private int _selectedItem = -1;
 
         public int ItemCount => _dropDownItems.Count;

--- a/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
+++ b/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
@@ -19,6 +19,8 @@ namespace uguimvvm
 
         public int ItemCount => _dropDownItems.Count;
 
+        public int SelectedIndex => _selectedItem;
+
         public void Add(DropDownItem item)
         {
             if (item.IsSelected)

--- a/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
+++ b/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
@@ -35,6 +35,16 @@ namespace uguimvvm
         /// <param name="position"></param>
         public void OnGUI(Rect position)
         {
+            OnGUI(dropDownContent => EditorGUI.Popup(position, _selectedItem, dropDownContent));
+        }
+
+        public void OnGUI(string label)
+        {
+            OnGUI(dropDownContent => EditorGUILayout.Popup(new GUIContent(label), _selectedItem, dropDownContent));
+        }
+
+        private void OnGUI(Func<GUIContent[], int> showPopup)
+        {
             var dropDownContent = new GUIContent[_dropDownItems.Count];
             for (int i = 0; i < dropDownContent.Length; i++)
             {
@@ -50,7 +60,7 @@ namespace uguimvvm
                 }
             }
 
-            var clickedIndex = EditorGUI.Popup(position, _selectedItem, dropDownContent);
+            var clickedIndex = showPopup(dropDownContent);
 
             if (clickedIndex != _selectedItem)
             {

--- a/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
@@ -95,7 +95,8 @@ class PropertyBindingEditor : Editor
 
     static void FigureViewBinding(PropertyBinding binding)
     {
-        if (binding.Mode == BindingMode.OneWayToTarget)
+        // Don't register for the target event that indicates the property has changed if the value from the target never flows back to the source.
+        if (!binding.Mode.IsSourceBoundToTarget())
         {
             return;
         }
@@ -210,11 +211,13 @@ class PropertyBindingEditor : Editor
 
         EditorGUILayout.PropertyField(vprop, new GUIContent(vprop.displayName, "Typically, the Target would be a View"));
 
-        var epropcount = DrawCrefEvents(vprop, veprop);
+        // If the value never flows back from the target to the source, then there is no reason to pay attention to value change events on the target.
+        int epropcount = ((PropertyBinding)target).Mode.IsSourceBoundToTarget() ? DrawCrefEvents(vprop, veprop) : -1;
 
         EditorGUILayout.PropertyField(vmprop, new GUIContent(vmprop.displayName, "Typically, the Source would be a ViewModel"));
 
         EditorGUILayout.PropertyField(mprop, false);
+
         if (epropcount == 0)
         {
             if (mprop.enumValueIndex > 1)

--- a/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
@@ -23,7 +23,7 @@ class PropertyBindingEditor : Editor
 #if UNITY_2017_2_5_OR_NEWER
         EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
 #endif
-        FigureViewBindings();
+        FigureUnityEventTriggeredBindings();
     }
 
 #if UNITY_2017_2_5_OR_NEWER
@@ -34,9 +34,14 @@ class PropertyBindingEditor : Editor
         {
             foreach (var binding in cachedBindings)
             {
-                if (binding.Mode != BindingMode.OneWayToView)
+                if (binding.Mode != BindingMode.OneWayToTarget)
                 {
-                    RemoveViewBinding(binding);
+                    RemoveViewBinding(binding, "_target", "_targetEvent");
+                }
+
+                if (binding.Mode != BindingMode.OneWayToSource)
+                {
+                    RemoveViewBinding(binding, "_source", "_sourceEvent");
                 }
             }
             cachedBindings.Clear();
@@ -45,20 +50,20 @@ class PropertyBindingEditor : Editor
     }
 #endif
 
-    static void RemoveViewBinding(PropertyBinding binding)
+    static void RemoveViewBinding(PropertyBinding binding, string componentPathPropertyName, string eventPropertyName)
     {
         var sobj = new SerializedObject(binding);
-        var vevValue = GetViewEventValue(sobj);
-        if (vevValue != null)
+        var unityEvent = GetEventValue(sobj, componentPathPropertyName, eventPropertyName);
+        if (unityEvent != null)
         {
-            var eventCount = vevValue.GetPersistentEventCount();
+            var eventCount = unityEvent.GetPersistentEventCount();
             for (var idx = 0; idx < eventCount; idx++)
             {
-                var perTarget = vevValue.GetPersistentTarget(idx);
+                var perTarget = unityEvent.GetPersistentTarget(idx);
                 // this was a binding we added, let's remove it
                 if (perTarget == binding)
                 {
-                    UnityEditor.Events.UnityEventTools.RemovePersistentListener(vevValue, idx);
+                    UnityEditor.Events.UnityEventTools.RemovePersistentListener(unityEvent, idx);
                     eventCount--;
                     sobj.ApplyModifiedProperties();
                 }
@@ -66,34 +71,48 @@ class PropertyBindingEditor : Editor
         }
     }
 
-    private static UnityEventBase GetViewEventValue(SerializedObject sobj)
+    private static UnityEventBase GetEventValue(SerializedObject sobj, string componentPathPropertyName, string eventPropertyName)
     {
-        var viewEvProp = sobj.FindProperty("_targetEvent");
-        if (string.IsNullOrEmpty(viewEvProp.stringValue))
+        var eventProperty = sobj.FindProperty(eventPropertyName);
+        if (string.IsNullOrEmpty(eventProperty.stringValue))
             return null;
 
-        var viewProp = sobj.FindProperty("_target");
-        var vcprop = viewProp.FindPropertyRelative("Component");
+        var componentPathProperty = sobj.FindProperty(componentPathPropertyName);
+        var componentProperty = componentPathProperty.FindPropertyRelative(nameof(PropertyBinding.ComponentPath.Component));
 
-        var vcomp = vcprop.objectReferenceValue as Component;
-        if (vcomp == null)
+        var component = componentProperty.objectReferenceValue as Component;
+        if (component == null)
             return null;
 
-        return GetEvent(vcomp, viewEvProp);
+        return GetEvent(component, eventProperty);
     }
 
-    private static void FigureViewBindings()
+    private static void FigureUnityEventTriggeredBindings()
     {
         var objects = Resources.FindObjectsOfTypeAll<GameObject>();
         foreach (var obj in objects)
         {
             var bindings = obj.GetComponents<PropertyBinding>();
             foreach (var binding in bindings)
-                FigureViewBinding(binding);
+            {
+                FigureSourceBinding(binding);
+                FigureTargetBinding(binding);
+            }
         }
     }
 
-    static void FigureViewBinding(PropertyBinding binding)
+    private static void FigureSourceBinding(PropertyBinding binding)
+    {
+        // Don't register for the target event that indicates the property has changed if the value from the target never flows back to the source.
+        if (!binding.Mode.IsTargetBoundToSource())
+        {
+            return;
+        }
+
+        FigureBinding(binding, "_source", "_sourceEvent", binding.ApplySourceToTarget);
+    }
+
+    private static void FigureTargetBinding(PropertyBinding binding)
     {
         // Don't register for the target event that indicates the property has changed if the value from the target never flows back to the source.
         if (!binding.Mode.IsSourceBoundToTarget())
@@ -101,16 +120,21 @@ class PropertyBindingEditor : Editor
             return;
         }
 
+        FigureBinding(binding, "_target", "_targetEvent", binding.ApplyTargetToSource);
+    }
+
+    private static void FigureBinding(PropertyBinding binding, string componentPathPropertyName, string eventPropertyName, UnityAction handler)
+    {
         var sobj = new SerializedObject(binding);
-        var vevValue = GetViewEventValue(sobj);
-        if (vevValue != null)
+        var unityEvent = GetEventValue(sobj, componentPathPropertyName, eventPropertyName);
+        if (unityEvent != null)
         {
             cachedBindings.Add(binding);
-            var eventCount = vevValue.GetPersistentEventCount();
+            var eventCount = unityEvent.GetPersistentEventCount();
 
             for (var idx = 0; idx < eventCount; idx++)
             {
-                var perTarget = vevValue.GetPersistentTarget(idx);
+                var perTarget = unityEvent.GetPersistentTarget(idx);
                 // if we find a duplicate event skip over adding it
                 if (perTarget == binding)
                 {
@@ -118,7 +142,7 @@ class PropertyBindingEditor : Editor
                 }
             }
 
-            UnityEditor.Events.UnityEventTools.AddVoidPersistentListener(vevValue, binding.ApplyVToVM);
+            UnityEditor.Events.UnityEventTools.AddVoidPersistentListener(unityEvent, handler);
         }
 
         sobj.ApplyModifiedProperties();
@@ -203,91 +227,39 @@ class PropertyBindingEditor : Editor
     {
         serializedObject.Update();
 
-        var vprop = serializedObject.FindProperty("_target");
-        var vmprop = serializedObject.FindProperty("_source");
+        var target = serializedObject.FindProperty("_target");
         var targetUpdateTrigger = serializedObject.FindProperty("_targetUpdateTrigger");
-        var veprop = serializedObject.FindProperty("_targetEvent");
-        var cprop = serializedObject.FindProperty("_converter");
-        var mprop = serializedObject.FindProperty("_mode");
+        var targetEvent = serializedObject.FindProperty("_targetEvent");
 
-        using (var changeScope = new EditorGUI.ChangeCheckScope())
+        var source = serializedObject.FindProperty("_source");
+        var sourceUpdateTrigger = serializedObject.FindProperty("_sourceUpdateTrigger");
+        var sourceEvent = serializedObject.FindProperty("_sourceEvent");
+
+        var converter = serializedObject.FindProperty("_converter");
+        var mode = serializedObject.FindProperty("_mode");
+
+        int targetTriggerCount = DrawBindingComponent(target, "Typically, the Target would be a View", targetUpdateTrigger, targetEvent, ((BindingMode)mode.intValue).IsSourceBoundToTarget(), false);
+
+        int sourceTriggerCount = DrawBindingComponent(source, "Typically, the Source would be a ViewModel", sourceUpdateTrigger, sourceEvent, ((BindingMode)mode.intValue).IsTargetBoundToSource(), true);
+
+        EditorGUILayout.PropertyField(mode, false);
+
+        if (targetTriggerCount == 0 && ((BindingMode)mode.intValue).IsSourceBoundToTarget())
         {
-            EditorGUILayout.PropertyField(vprop, new GUIContent(vprop.displayName, "Typically, the Target would be a View"));
-            // If the binding target changes, reset the binding update trigger (since the type of the target will determine the available update triggers)
-            if (changeScope.changed)
-            {
-                targetUpdateTrigger.enumValueIndex = (int)BindingUpdateTrigger.None;
-                veprop.stringValue = null;
-            }
+            EditorUtility.DisplayDialog("Error", string.Format("Cannot change {0} to {1}, as only {2} and {3} are valid for no target updated event",
+                mode.displayName, mode.enumNames[mode.enumValueIndex], nameof(BindingMode.OneTime), nameof(BindingMode.OneWayToTarget)), "Okay");
+            mode.intValue = (int)BindingMode.OneTime;
         }
 
-        Type targetType = PropertyBinding.GetComponentType((Component)vprop.FindPropertyRelative(nameof(PropertyBinding.ComponentPath.Component)).objectReferenceValue, false);
-        bool isTargetINotifyPropertyChanged = typeof(System.ComponentModel.INotifyPropertyChanged).IsAssignableFrom(targetType);
-        // Try to set the target update trigger to a reasonable default
-        if (targetUpdateTrigger.enumValueIndex == (int)BindingUpdateTrigger.None)
+        if (sourceTriggerCount == 0 && ((BindingMode)mode.intValue).IsTargetBoundToSource())
         {
-            if (isTargetINotifyPropertyChanged)
-            {
-                targetUpdateTrigger.enumValueIndex = (int)BindingUpdateTrigger.PropertyChangedEvent;
-            }
-        }
-
-        // If the value never flows back from the target to the source, then there is no reason to pay attention to value change events on the target.
-        int epropcount = -1;
-        if (((PropertyBinding)target).Mode.IsSourceBoundToTarget())
-        {
-            var dropDownMenu = new DropDownMenu();
-
-            if (isTargetINotifyPropertyChanged)
-            {
-                dropDownMenu.Add(new DropDownItem { Label = "Property Changed", IsSelected = targetUpdateTrigger.enumValueIndex == (int)BindingUpdateTrigger.PropertyChangedEvent, Command = () =>
-                {
-                    targetUpdateTrigger.enumValueIndex = (int)BindingUpdateTrigger.PropertyChangedEvent;
-                    veprop.stringValue = null;
-                }});
-            }
-
-            List<DropDownItem> unityEvents = PropertyBindingEditor.GetDropUnityEventDownItems(targetType, veprop.stringValue, unityEvent =>
-            {
-                veprop.stringValue = unityEvent;
-                targetUpdateTrigger.enumValueIndex = (int)BindingUpdateTrigger.UnityEvent;
-            }).ToList();
-
-            if (dropDownMenu.ItemCount > 0 && unityEvents.Any())
-            {
-                dropDownMenu.Add(new DropDownItem());
-            }
-
-            unityEvents.ForEach(dropDownItem => dropDownMenu.Add(dropDownItem));
-
-            // Only show the update trigger dropdown if there is more than one choice
-            if (dropDownMenu.ItemCount > 1)
-            {
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    dropDownMenu.OnGUI("Event");
-                }
-            }
-
-            epropcount = dropDownMenu.ItemCount;
-        }
-
-        EditorGUILayout.PropertyField(vmprop, new GUIContent(vmprop.displayName, "Typically, the Source would be a ViewModel"));
-
-        EditorGUILayout.PropertyField(mprop, false);
-
-        if (epropcount == 0)
-        {
-            if (mprop.enumValueIndex > 1)
-            {
-                EditorUtility.DisplayDialog("Error", string.Format("Cannot change {0} to {1}, as only {2} and {3} are valid for no event",
-                    mprop.displayName, (BindingMode)mprop.enumValueIndex, BindingMode.OneTime, BindingMode.OneWayToTarget), "Okay");
-                mprop.enumValueIndex = 1;
-            }
+            EditorUtility.DisplayDialog("Error", string.Format("Cannot change {0} to {1}, as only {2} and {3} are valid for no source updated event",
+                mode.displayName, mode.enumNames[mode.enumValueIndex], nameof(BindingMode.OneTime), nameof(BindingMode.OneWayToSource)), "Okay");
+            mode.intValue = (int)BindingMode.OneTime;
         }
 
         var position = EditorGUILayout.GetControlRect(true);
-        ComponentReferenceDrawer.PropertyField(position, cprop);
+        ComponentReferenceDrawer.PropertyField(position, converter);
 
         serializedObject.ApplyModifiedProperties();
     }
@@ -349,6 +321,78 @@ class PropertyBindingEditor : Editor
             return null;
         var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
         return t.GetField(name, flags) ?? GetField(t.BaseType, name);
+    }
+
+    private static int DrawBindingComponent(SerializedProperty componentPathProperty, string componentDescription, SerializedProperty updateTriggerProperty, SerializedProperty unityEventProperty, bool enableUpdateTriggers, bool resolveDataContext)
+    {
+        using (var changeScope = new EditorGUI.ChangeCheckScope())
+        {
+            EditorGUILayout.PropertyField(componentPathProperty, new GUIContent(componentPathProperty.displayName, componentDescription));
+            // If the binding target changes, reset the binding update trigger (since the type of the target will determine the available update triggers)
+            if (changeScope.changed)
+            {
+                updateTriggerProperty.intValue = (int)BindingUpdateTrigger.None;
+                unityEventProperty.stringValue = null;
+            }
+        }
+
+        Type resolvedType = PropertyBinding.GetComponentType((Component)componentPathProperty.FindPropertyRelative(nameof(PropertyBinding.ComponentPath.Component)).objectReferenceValue, resolveDataContext);
+        bool isINotifyPropertyChanged = typeof(System.ComponentModel.INotifyPropertyChanged).IsAssignableFrom(resolvedType);
+        // Try to set the target update trigger to a reasonable default
+        if (updateTriggerProperty.intValue == (int)BindingUpdateTrigger.None)
+        {
+            if (isINotifyPropertyChanged)
+            {
+                updateTriggerProperty.intValue = (int)BindingUpdateTrigger.PropertyChangedEvent;
+            }
+        }
+
+        // If the value never flows back from the target to the source, then there is no reason to pay attention to value change events on the target.
+        int updateTriggerCount = -1;
+        if (enableUpdateTriggers)
+        {
+            var dropDownMenu = new DropDownMenu();
+
+            if (isINotifyPropertyChanged)
+            {
+                dropDownMenu.Add(new DropDownItem
+                {
+                    Label = "Property Changed",
+                    IsSelected = updateTriggerProperty.intValue == (int)BindingUpdateTrigger.PropertyChangedEvent,
+                    Command = () =>
+                    {
+                        updateTriggerProperty.intValue = (int)BindingUpdateTrigger.PropertyChangedEvent;
+                        unityEventProperty.stringValue = null;
+                    }
+                });
+            }
+
+            List<DropDownItem> unityEvents = PropertyBindingEditor.GetDropUnityEventDownItems(resolvedType, unityEventProperty.stringValue, unityEvent =>
+            {
+                unityEventProperty.stringValue = unityEvent;
+                updateTriggerProperty.intValue = (int)BindingUpdateTrigger.UnityEvent;
+            }).ToList();
+
+            if (dropDownMenu.ItemCount > 0 && unityEvents.Any())
+            {
+                dropDownMenu.Add(new DropDownItem());
+            }
+
+            unityEvents.ForEach(dropDownItem => dropDownMenu.Add(dropDownItem));
+
+            // Only show the update trigger dropdown if there is more than one choice
+            if (dropDownMenu.ItemCount > 1)
+            {
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    dropDownMenu.OnGUI("Event");
+                }
+            }
+
+            updateTriggerCount = dropDownMenu.ItemCount;
+        }
+
+        return updateTriggerCount;
     }
 
     private static IEnumerable<DropDownItem> GetDropUnityEventDownItems(Type componentType, string currentEvent, Action<string> onEventSelected)

--- a/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
@@ -109,7 +109,7 @@ class PropertyBindingEditor : Editor
             return;
         }
 
-        FigureBinding(binding, "_source", "_sourceEvent", binding.ApplySourceToTarget);
+        FigureBinding(binding, "_source", "_sourceEvent", binding.UpdateTarget);
     }
 
     private static void FigureTargetBinding(PropertyBinding binding)
@@ -120,7 +120,7 @@ class PropertyBindingEditor : Editor
             return;
         }
 
-        FigureBinding(binding, "_target", "_targetEvent", binding.ApplyTargetToSource);
+        FigureBinding(binding, "_target", "_targetEvent", binding.UpdateSource);
     }
 
     private static void FigureBinding(PropertyBinding binding, string componentPathPropertyName, string eventPropertyName, UnityAction handler)

--- a/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
@@ -387,6 +387,11 @@ class PropertyBindingEditor : Editor
                 {
                     dropDownMenu.OnGUI("Event");
                 }
+
+                if (dropDownMenu.SelectedIndex < 0)
+                {
+                    EditorGUILayout.HelpBox($"Select an event that indicates the property has changed, or update the binding mode.", MessageType.Warning);
+                }
             }
 
             updateTriggerCount = dropDownMenu.ItemCount;

--- a/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
+++ b/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
@@ -62,6 +62,7 @@ namespace uguimvvm
                     .AsParallel()
                     .WithCancellation(cancellationToken)
                     .Select((t) => new TypeSuggestion(t, currentValue))
+                    .Where((t) => Attribute.GetCustomAttribute(t, typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)) == null)
                     .Where((s) => s.DisplayTextMatchIndex >= 0)
                     .OrderBy(opt => opt.DisplayTextMatchIndex)
                     .ThenBy(opt => opt.Value.Length)

--- a/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
+++ b/src/Assets/ugui-mvvm/Editor/TypeSuggestionProvider.cs
@@ -61,8 +61,8 @@ namespace uguimvvm
                 results = _types
                     .AsParallel()
                     .WithCancellation(cancellationToken)
-                    .Select((t) => new TypeSuggestion(t, currentValue))
                     .Where((t) => Attribute.GetCustomAttribute(t, typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute)) == null)
+                    .Select((t) => new TypeSuggestion(t, currentValue))
                     .Where((s) => s.DisplayTextMatchIndex >= 0)
                     .OrderBy(opt => opt.DisplayTextMatchIndex)
                     .ThenBy(opt => opt.Value.Length)

--- a/src/Assets/ugui-mvvm/PropertyBinding.cs
+++ b/src/Assets/ugui-mvvm/PropertyBinding.cs
@@ -342,15 +342,15 @@ namespace uguimvvm
             return 10;
         }
 
-        void Awake()
+        private void Awake()
         {
             _ci = _converter as IValueConverter;
-
-            FigureBindings();
         }
 
-        void OnEnable()
+        private void OnEnable()
         {
+            FigureBindings();
+
             ApplyVMToV();
 
             if (_mode == BindingMode.OneTime)
@@ -360,7 +360,7 @@ namespace uguimvvm
             }
         }
 
-        void OnDestroy()
+        private void OnDisable()
         {
             ClearBindings();
         }

--- a/src/Assets/ugui-mvvm/PropertyBinding.cs
+++ b/src/Assets/ugui-mvvm/PropertyBinding.cs
@@ -532,9 +532,6 @@ namespace uguimvvm
             }
         }
 
-        // TODO: Want to pass in a BindingUpdateTrigger here so it can decide whether it is handling an INPC event or a Unity event, but currently these two event handler types are managed completely differently (see PropertyBindingEditor::FigureViewBinding)
-        // Actually seems like maybe this isn't needed. Instead, this one will always handle INPC events and PropertyBindingEditor::FigureViewBinding will always handle UnityEvents
-        // Then just need to figure out how to bring in polling.
         public static PropertyPath FigureBinding(ComponentPath path, Action handler, bool resolveDataContext)
         {
             Type type = PropertyBinding.GetComponentType(path.Component, resolveDataContext);

--- a/src/Assets/ugui-mvvm/PropertyBinding.cs
+++ b/src/Assets/ugui-mvvm/PropertyBinding.cs
@@ -356,12 +356,12 @@ namespace uguimvvm
         private void Awake()
         {
             _ci = _converter as IValueConverter;
+
+            FigureBindings();
         }
 
         private void OnEnable()
         {
-            FigureBindings();
-
             ApplySourceToTarget();
 
             if (_mode == BindingMode.OneTime)
@@ -371,7 +371,7 @@ namespace uguimvvm
             }
         }
 
-        private void OnDisable()
+        private void OnDestroy()
         {
             ClearBindings();
         }

--- a/src/Assets/ugui-mvvm/PropertyBinding.cs
+++ b/src/Assets/ugui-mvvm/PropertyBinding.cs
@@ -297,15 +297,13 @@ namespace uguimvvm
         [SerializeField]
         private BindingUpdateTrigger _targetUpdateTrigger = BindingUpdateTrigger.None;
 
-#pragma warning disable 0169
+#pragma warning disable 0414 // _targetEvent is not used directly, only via SerializedObject.FindProperty
 
         [SerializeField]
         [FormerlySerializedAs("_viewEvent")]
-        string _targetEvent;
+        string _targetEvent = null;
 
-#if !UNITY_EDITOR
-#pragma warning restore 0169
-#endif
+#pragma warning restore 0414
 
         [SerializeField]
         [FormerlySerializedAs("_viewModel")]
@@ -315,7 +313,7 @@ namespace uguimvvm
         [SerializeField]
         private BindingUpdateTrigger _sourceUpdateTrigger = BindingUpdateTrigger.None;
 
-#pragma warning disable 0414
+#pragma warning disable 0414 // _sourceEvent is not used directly, only via SerializedObject.FindProperty
 
         [SerializeField]
         private string _sourceEvent = null;
@@ -362,7 +360,7 @@ namespace uguimvvm
 
         private void OnEnable()
         {
-            ApplySourceToTarget();
+            UpdateTarget();
 
             if (_mode == BindingMode.OneTime)
             {
@@ -376,13 +374,13 @@ namespace uguimvvm
             ClearBindings();
         }
 
-        [Obsolete("Use ApplyTargetToSource")]
+        [Obsolete("Use UpdateSource")]
         public void ApplyVToVM()
         {
-            ApplyTargetToSource();
+            UpdateSource();
         }
 
-        public void ApplyTargetToSource()
+        public void UpdateSource()
         {
             //Debug.Log("Applying v to vm");
             if (_vmProp == null || _vProp == null) return;
@@ -414,13 +412,13 @@ namespace uguimvvm
             SetVmValue(value);
         }
 
-        [Obsolete("Use ApplySourceToTarget")]
+        [Obsolete("Use UpdateTarget")]
         public void ApplyVMToV()
         {
-            ApplySourceToTarget();
+            UpdateTarget();
         }
 
-        public void ApplySourceToTarget()
+        public void UpdateTarget()
         {
             if (_vmProp == null || _vProp == null) return;
 
@@ -499,7 +497,7 @@ namespace uguimvvm
             Action sourceUpdateHandler = null;
             if (_sourceUpdateTrigger != BindingUpdateTrigger.UnityEvent)
             {
-                sourceUpdateHandler = ApplySourceToTarget;
+                sourceUpdateHandler = UpdateTarget;
             }
             _vmProp = FigureBinding(_source, sourceUpdateHandler, true);
 
@@ -507,7 +505,7 @@ namespace uguimvvm
             Action targetUpdateHandler = null;
             if (_targetUpdateTrigger != BindingUpdateTrigger.UnityEvent)
             {
-                targetUpdateHandler = ApplyTargetToSource;
+                targetUpdateHandler = UpdateSource;
             }
             _vProp = FigureBinding(_target, targetUpdateHandler, false);
 


### PR DESCRIPTION
This change makes source bindings and target bindings nearly identical. This means two things:

1. Source bindings can trigger an update to the target based on a `UnityEventBase`.
2. Target bindings can trigger an update to the source based on a `PropertyChanged`.

Previously, the source of bindings was processed by `PropertyBinding.FigureBindings` (for `INotifyPropertyChanged`) and the target of bindings was processed by `PropertyBindingEditor.FigureViewBindings` (for `UnityEventBase`). Now, both source and target bindings are processed in both ways (but only one will take affect, depending on how the binding has been configured).

Here is how this shows up in the editor for a pure view-to-view binding:
![image](https://user-images.githubusercontent.com/5084643/64398751-e7e85180-d01a-11e9-894e-095c4620a245.png)

In the case where a source or target of the binding is both a `MonoBehaviour` with one or more `UnityEventBase` _and_ implements `INotifyPropertyChanged`, then both options show up:
![image](https://user-images.githubusercontent.com/5084643/64398813-23831b80-d01b-11e9-873d-ffd2354c588a.png)

In the case where the source or target of the binding is a `MonoBehaviour` that implements `INotifyPropertyChanged` and has exposes no `UnityEventBase` members, then `PropertyChanged` is the only option and so no option is shown (`PropertyChanged` is automatically selected since it is the only choice). This is to make the common case super simple.
![image](https://user-images.githubusercontent.com/5084643/64398991-a6a47180-d01b-11e9-8d95-36712d2b0ed1.png)

In both cases (source and target), the dropdown only shows up if the binding mode indicates that the source or target can trigger an update.

@ritijain