### PR TITLE
InheritDoc Correction

### DIFF
--- a/src/Assets/ugui-mvvm/ICommand.cs
+++ b/src/Assets/ugui-mvvm/ICommand.cs
@@ -72,7 +72,9 @@ namespace uguimvvm
                 CanExecuteChanged(this, EventArgs.Empty);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Occurs when changes occur that affect whether or not the command should execute.
+        /// </summary>
         public event EventHandler CanExecuteChanged;
     }
 
@@ -121,7 +123,9 @@ namespace uguimvvm
                 CanExecuteChanged(this, EventArgs.Empty);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Occurs when changes occur that affect whether or not the command should execute.
+        /// </summary>
         public event EventHandler CanExecuteChanged;
     }
 }


### PR DESCRIPTION
Replace inheritdoc on CanExecuteChanged, which can apparently cause build-time issue for SauceControl for some UAP configurations.