### PR TITLE
Quick fix to autoselect the first event if there is only one available

### DIFF
--- a/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
+++ b/src/Assets/ugui-mvvm/Editor/DropDownMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -33,6 +34,8 @@ namespace uguimvvm
     {
         private readonly List<DropDownItem> _dropDownItems = new List<DropDownItem>();
         private int _selectedItem = -1;
+
+        public List<DropDownItem> Items => _dropDownItems.ToList();
 
         /// <summary>
         /// The number of items in the list.

--- a/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
+++ b/src/Assets/ugui-mvvm/Editor/PropertyBindingEditor.cs
@@ -393,8 +393,12 @@ class PropertyBindingEditor : Editor
                     EditorGUILayout.HelpBox($"Select an event that indicates the property has changed, or update the binding mode.", MessageType.Warning);
                 }
             }
+			else if (dropDownMenu.ItemCount == 1)
+			{
+                dropDownMenu.Items[0].Command();
+			}
 
-            updateTriggerCount = dropDownMenu.ItemCount;
+			updateTriggerCount = dropDownMenu.ItemCount;
         }
 
         return updateTriggerCount;


### PR DESCRIPTION
When binding to Unity's Dropdown component i noticed there is no event trigger dropdown in the inspector because it only gets displayed if you have the choice between multiple events. But this way no event was ever selected if there is just one (OnValueChanged in case of the Dropdown component).

This PR autoselects the first one.