### PR TITLE
Harden PropertyBinding's AddHandler to ensure that property is readable before traversing

### DIFF
--- a/src/Assets/ugui-mvvm/PropertyBinding.cs
+++ b/src/Assets/ugui-mvvm/PropertyBinding.cs
@@ -259,7 +259,7 @@ namespace uguimvvm
 
                     TrySubscribe(root, i);
 
-                    if (root != null)
+                    if (root != null && part.CanRead)
                         root = part.GetValue(root, null);
                     else
                         break;


### PR DESCRIPTION
This is a bug exposed as part of commit [644a5cc](https://github.com/jbruening/ugui-mvvm/commit/644a5cc6baf2c79d30b4e24776b514845da94b8c)

In addition to Source -> Target, bindings are also checking for Target -> Source.

This can cause issues if the Target's path only exposes setters. The PropertyBinding's AddHandler implementation does not correctly handle that case (it always assumes properties are both read/write).

The fix is trivial, we simply ensure that property is readable before accessing it.